### PR TITLE
ajout d'un paramètre admin pour choisir l'adresse de destination 

### DIFF
--- a/lang/en/local_casesending.php
+++ b/lang/en/local_casesending.php
@@ -46,3 +46,5 @@ $string["banner1Explain"] = 'Here, fill the informations that must be displayed 
 $string["banner2Explain"] = 'Here, fill the informations that must be displayed in the information banner n°2.';
 $string["banner3Explain"] = 'Here, fill the informations that must be displayed in the information banner n°3.';
 $string["banner4Explain"] = 'Here, fill the informations that must be displayed in the information banner n°4.';
+$string["recipientemail"] = "Recipient's Email Address";
+$string["recipientemail_desc"] = "Assistance emails will be sent to this address.";

--- a/lang/fr/local_casesending.php
+++ b/lang/fr/local_casesending.php
@@ -44,3 +44,5 @@ $string["banner1Explain"] = 'Ici, vous saisissez les informations qui doivent ê
 $string["banner2Explain"] = 'Ici, vous saisissez les informations qui doivent être affichées dans la banière d\'information n°2.';
 $string["banner3Explain"] = 'Ici, vous saisissez les informations qui doivent être affichées dans la banière d\'information n°3.';
 $string["banner4Explain"] = 'Ici, vous saisissez les informations qui doivent être affichées dans la banière d\'information n°4.';
+$string["recipientemail"] = 'Adresse de destination';
+$string["recipientemail_desc"] = "Les mails d'assistance seront envoyés à cette adresse";

--- a/sending.php
+++ b/sending.php
@@ -7,7 +7,8 @@ global $DB;
 define("SITE_NAME", "MOODLE UGA"); // I added that
 
 $emailuser = new stdClass();
-$emailuser->email = "florent.paccalet@grenet.fr";//"sos-dapi@univ-grenoble-alpes.fr";
+$recipientemail = get_config('local_casesending', 'recipientemail');
+$emailuser->email = $recipientemail;
 $emailuser->id = -99;
 
 

--- a/settings.php
+++ b/settings.php
@@ -62,6 +62,12 @@ if ($hassiteconfig) {
                                                     get_string('banner4', 'local_casesending'),
                                                     get_string('banner4Explain', 'local_casesending'),
                                                     $default));
-
+    $settings->add(new admin_setting_configtext(
+        'local_casesending/recipientemail',
+        get_string('recipientemail', 'local_casesending'),
+        get_string('recipientemail_desc', 'local_casesending'),
+        'assistance@exemple.fr', // Valeur par défaut
+        PARAM_EMAIL
+    ));    
     $ADMIN->add('localplugins', $settings);
 }


### PR DESCRIPTION
Actuellement l'adresse de destination est codée en dur; ces modifs rajouteront un paramètre admin pour la déterminer (et donc la modifier) depuis l'admin.